### PR TITLE
Screen texture and scan lines are now affected by curvature

### DIFF
--- a/crt_material.tres
+++ b/crt_material.tres
@@ -11,3 +11,4 @@ shader_param/show_grille = true
 shader_param/show_scanlines = true
 shader_param/show_vignette = true
 shader_param/show_curvature = true
+shader_param/screen_size = Vector2( 320, 180 )

--- a/crt_material.tres
+++ b/crt_material.tres
@@ -4,11 +4,10 @@
 
 [resource]
 shader = ExtResource( 1 )
-shader_param/blend_color = Color( 1, 1, 1, 1 )
 shader_param/boost = 1.2
-shader_param/vignette_opacity = 0.35
+shader_param/vignette_opacity = 0.3
+shader_param/scanline_speed = 1.0
 shader_param/show_grille = true
 shader_param/show_scanlines = true
 shader_param/show_vignette = true
 shader_param/show_curvature = true
-

--- a/crt_shader.shader
+++ b/crt_shader.shader
@@ -1,9 +1,9 @@
 shader_type canvas_item;
-render_mode blend_mul;
+render_mode blend_mix;
 
-uniform vec4 blend_color : hint_color = vec4(1.0, 1.0, 1.0, 1.0);
-uniform float boost : hint_range(1.0, 1.5, 0.05) = float(1.2);
-uniform float vignette_opacity : hint_range(0.1, 0.5, 0.05) = float(0.3);
+uniform float boost : hint_range(1.0, 1.5, 0.01) = float(1.2);
+uniform float vignette_opacity : hint_range(0.1, 0.5, 0.01) = float(0.3);
+uniform float scanline_speed : hint_range(0.0, 1.0, 0.01) = float(1.0);
 uniform bool show_grille = true; // Grille only works in Stretch Mode: 2D.
 uniform bool show_scanlines = true;
 uniform bool show_vignette = true;
@@ -19,7 +19,7 @@ vec2 CRTCurveUV(vec2 uv) {
 	return uv;
 }
 
-void DrawVignette(inout vec4 color, vec2 uv) {
+void DrawVignette(inout vec3 color, vec2 uv) {
 	if(show_vignette) {
 		float vignette = uv.x * uv.y * (1.0 - uv.x) * (1.0 - uv.y);
 		vignette = clamp(pow(16.0 * vignette, vignette_opacity), 0.0, 1.0);
@@ -29,10 +29,10 @@ void DrawVignette(inout vec4 color, vec2 uv) {
 	}
 }
 
-void DrawScanline(inout vec4 color, vec2 uv, float time) {
+void DrawScanline(inout vec3 color, vec2 uv, float time) {
 	float scanline = clamp(0.95 + 0.05 * cos(3.14 * (uv.y + 0.008 * time) * 240.0 * 1.0), 0.0, 1.0);
 	float grille = 0.85 + 0.15 * clamp(1.5 * cos(3.14 * uv.x * 640.0 * 1.0), 0.0, 1.0);
-
+	
 	if(show_scanlines && !show_grille) {
 		color *= scanline * boost;
 	} else if(!show_scanlines && show_grille) {
@@ -45,15 +45,16 @@ void DrawScanline(inout vec4 color, vec2 uv, float time) {
 }
 
 void fragment() {
-	vec4 color = blend_color;
-
+	vec2 screen_crtUV = CRTCurveUV(SCREEN_UV);
+	vec3 color = texture(SCREEN_TEXTURE, screen_crtUV).rgb;
+	
 	vec2 crtUV = CRTCurveUV(UV);
 	if (crtUV.x < 0.0 || crtUV.x > 1.0 || crtUV.y < 0.0 || crtUV.y > 1.0) {
-		color = vec4(0.0, 0.0, 0.0, 1.0);
+		color = vec3(0.0, 0.0, 0.0);
 	}
-
+	
 	DrawVignette(color, crtUV);
-	DrawScanline(color, UV, TIME);
-
-	COLOR = vec4(color);
+	DrawScanline(color, crtUV, TIME * scanline_speed);
+	
+	COLOR = vec4(color, 1.0);
 }

--- a/crt_shader.shader
+++ b/crt_shader.shader
@@ -8,6 +8,7 @@ uniform bool show_grille = true; // Grille only works in Stretch Mode: 2D.
 uniform bool show_scanlines = true;
 uniform bool show_vignette = true;
 uniform bool show_curvature = true;
+uniform vec2 screen_size = vec2(480.0, 270.0);
 
 vec2 CRTCurveUV(vec2 uv) {
 	if(show_curvature) {
@@ -30,18 +31,18 @@ void DrawVignette(inout vec3 color, vec2 uv) {
 }
 
 void DrawScanline(inout vec3 color, vec2 uv, float time) {
-	float scanline = clamp(0.95 + 0.05 * cos(3.14 * (uv.y + 0.008 * time) * 240.0 * 1.0), 0.0, 1.0);
-	float grille = 0.85 + 0.15 * clamp(1.5 * cos(3.14 * uv.x * 640.0 * 1.0), 0.0, 1.0);
+	float scanline = clamp(0.95 + 0.05 * sin(3.14159 * (uv.y + 0.008 * time) * screen_size.y), 0.0, 1.0);
+	float grille = 0.85 + 0.15 * clamp(1.5 * sin(3.14159 * uv.x * screen_size.x), 0.0, 1.0);
 	
-	if(show_scanlines && !show_grille) {
-		color *= scanline * boost;
-	} else if(!show_scanlines && show_grille) {
-		color *= grille * boost;
-	} else if(show_scanlines && show_grille) {
-		color *= scanline * grille * boost;
-	} else {
-		color *= boost;
+	if(show_scanlines) {
+		color *= scanline
 	}
+	
+	if(show_grille) {
+		color *= grille
+	}
+	
+	color *= boost;
 }
 
 void fragment() {

--- a/demo_scene.tscn
+++ b/demo_scene.tscn
@@ -8,13 +8,17 @@
 [node name="background" type="ColorRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+color = Color( 0.8, 0.74902, 0.501961, 1 )
 
 [node name="icon" type="Sprite" parent="."]
-position = Vector2( 153.033, 91.1485 )
+position = Vector2( 71.3842, 70.2482 )
+texture = ExtResource( 1 )
+
+[node name="icon2" type="Sprite" parent="."]
+position = Vector2( 246.99, 107.356 )
 texture = ExtResource( 1 )
 
 [node name="CRTShader" type="ColorRect" parent="."]
 material = ExtResource( 2 )
 anchor_right = 1.0
 anchor_bottom = 1.0
-


### PR DESCRIPTION
The shader no longer multiplies what's behind it, and now uses the screen texture as the color, and applies curvature to the screen UV. Scanlines are also affected by curvature now. I also added an option to change the speed of the scanline movement.

![example](https://user-images.githubusercontent.com/11450875/61297457-47a84600-a7aa-11e9-8474-1c736b0eca5d.png)
