### PR TITLE
Make scanlines and grille non-destructive

### DIFF
--- a/crt_shader.shader
+++ b/crt_shader.shader
@@ -35,15 +35,15 @@ void DrawVignette(inout vec3 color, vec2 uv) {
 }
 
 void DrawScanline(inout vec3 color, vec2 uv, float time) {
-	float scanline = clamp((scanlines_opacity - 0.05) + 0.05 * sin(3.1415926535 * (uv.y + 0.008 * time) * screen_size.y), 0.0, 1.0);
-	float grille = (grille_opacity - 0.15) + 0.15 * clamp(1.5 * sin(3.1415926535 * uv.x * screen_size.x), 0.0, 1.0);
+	float scanline = clamp(sin(3.1415926535 * (uv.y + 0.008 * time) * screen_size.y), 0.0, 1.0);
+	float grille = clamp(1.5 * sin(3.1415926535 * uv.x * screen_size.x), 0.0, 1.0);
 
 	if (show_scanlines) {
-		color *= scanline;
+		color *= (1.0 - scanlines_opacity * scanline);
 	}
 
 	if (show_grille) {
-		color *= grille;
+		color *= (1.0 - grille_opacity * grille);
 	}
 
 	color *= boost;


### PR DESCRIPTION
Simple adjustment, but this allows the developer to lower the opacity of the scanlines and grille without resulting in a completely black screen, which is exactly what I needed for Bodge Dall!

https://www.reddit.com/r/godot/comments/j0yk4r/spent_the_weekend_building_this_arcadestyle/g7ho26u/